### PR TITLE
Adding new slot for api

### DIFF
--- a/src/terraform/heroes.tf
+++ b/src/terraform/heroes.tf
@@ -38,6 +38,7 @@ resource "azurerm_app_service" "heroesapi" {
   app_settings = {
     "APPINSIGHTS_INSTRUMENTATIONKEY" = azurerm_application_insights.heroesappinsights.instrumentation_key
     "ApplicationInsights:InstrumentationKey" = azurerm_application_insights.heroesappinsights.instrumentation_key
+    "Cors__0" = "https://heroesweb.azurewebsites.net"
   }
 }
 
@@ -58,6 +59,28 @@ resource "azurerm_app_service_slot" "heroesapislot" {
   app_settings = {
     "APPINSIGHTS_INSTRUMENTATIONKEY" = azurerm_application_insights.heroesappinsights.instrumentation_key
     "ApplicationInsights:InstrumentationKey" = azurerm_application_insights.heroesappinsights.instrumentation_key
+    "Cors__0" = "https://heroesweb.azurewebsites.net"
+  }
+}
+
+resource "azurerm_app_service_slot" "heroesapislotperf" {
+  name                = "performance"
+  app_service_name    = azurerm_app_service.heroesapi.name
+  location            = azurerm_resource_group.zerorg.location
+  resource_group_name = azurerm_resource_group.zerorg.name
+  app_service_plan_id = azurerm_app_service_plan.zerosp.id
+
+  site_config {
+    always_on                = true
+    dotnet_framework_version = "v4.0"
+    websockets_enabled       = true
+    managed_pipeline_mode    = "Integrated"
+  }
+
+  app_settings = {
+    "APPINSIGHTS_INSTRUMENTATIONKEY" = azurerm_application_insights.heroesappinsights.instrumentation_key
+    "ApplicationInsights:InstrumentationKey" = azurerm_application_insights.heroesappinsights.instrumentation_key
+    "Cors__0" = "https://heroesweb.azurewebsites.net"
   }
 }
 


### PR DESCRIPTION
Terraform plan:

 # azurerm_app_service_slot.heroesapislotperf will be created
  + resource "azurerm_app_service_slot" "heroesapislotperf" {
      + app_service_name        = "HeroesApi"
      + app_service_plan_id     = "/subscriptions/19ee435f-c645-4ac2-8fe1-b4c04e1d8872/resourceGroups/CodemotionRG/providers/Microsoft.Web/serverfarms/CodemotionSP"
      + app_settings            = {
          + "APPINSIGHTS_INSTRUMENTATIONKEY"         = "66c64fd6-9920-4b1d-8664-33288082ff63"
          + "ApplicationInsights:InstrumentationKey" = "66c64fd6-9920-4b1d-8664-33288082ff63"
          + "Cors__0"                                = "https://heroesweb.azurewebsites.net"
        }
      + client_affinity_enabled = (known after apply)
      + default_site_hostname   = (known after apply)
      + enabled                 = true
      + https_only              = false
      + id                      = (known after apply)
      + location                = "westeurope"
      + name                    = "performance"
      + resource_group_name     = "CodemotionRG"
      + site_credential         = (known after apply)

      + auth_settings {
          + additional_login_params        = (known after apply)
          + allowed_external_redirect_urls = (known after apply)
          + default_provider               = (known after apply)
          + enabled                        = (known after apply)
          + issuer                         = (known after apply)
          + runtime_version                = (known after apply)
          + token_refresh_extension_hours  = (known after apply)
          + token_store_enabled            = (known after apply)
          + unauthenticated_client_action  = (known after apply)

          + active_directory {
              + allowed_audiences = (known after apply)
              + client_id         = (known after apply)
              + client_secret     = (sensitive value)
            }     
        }

      + connection_string {
          + name  = (known after apply)
          + type  = (known after apply)
          + value = (sensitive value)
        }
 + identity {                                                                      
     + identity_ids = (known after apply)                                          
     + principal_id = (known after apply)                                          
     + tenant_id    = (known after apply)                                          
     + type         = (known after apply)                                          
   }                                                                               
                                                                                   
 + logs {                                                                          
     + detailed_error_messages_enabled = (known after apply)                       
     + failed_request_tracing_enabled  = (known after apply)                       
                                                                                   
     + application_logs {                                                          
         + file_system_level = (known after apply)                                 
                                                                                   
         + azure_blob_storage {                                                    
             + level             = (known after apply)                             
             + retention_in_days = (known after apply)                             
             + sas_url           = (sensitive value)                               
           }                                                                       
       }                                                                           
                                                                                   
     + http_logs {                                                                 
         + azure_blob_storage {                                                    
             + retention_in_days = (known after apply)                             
             + sas_url           = (sensitive value)                               
           }                                                                       
                                                                                   
         + file_system {                                                           
             + retention_in_days = (known after apply)                             
             + retention_in_mb   = (known after apply)                             
           }                                                                       
       }                                                                           
   }                                                                               
 + site_config {
          + always_on                   = true
          + dotnet_framework_version    = "v4.0"
          + ftps_state                  = (known after apply)
          + http2_enabled               = false
          + ip_restriction              = (known after apply)
          + linux_fx_version            = (known after apply)
          + local_mysql_enabled         = (known after apply)
          + managed_pipeline_mode       = "Integrated"
          + min_tls_version             = (known after apply)
          + number_of_workers           = (known after apply)
          + remote_debugging_enabled    = false
          + remote_debugging_version    = (known after apply)
          + scm_ip_restriction          = (known after apply)
          + scm_type                    = (known after apply)
          + scm_use_main_ip_restriction = false
          + websockets_enabled          = true
          + windows_fx_version          = (known after apply)

          + cors {
              + allowed_origins     = (known after apply)
              + support_credentials = (known after apply)
            }
        }
    }